### PR TITLE
Fixed bug in setMilliseconds() method.

### DIFF
--- a/index.js
+++ b/index.js
@@ -111,7 +111,7 @@ function setTimezone(timezone) {
   // Sets the milliseconds (from 0-999) in the current timezone
   this.setMilliseconds = function setMilliseconds(v) {
     var diff = v - this.getMilliseconds();
-    return this.setTime(this + diff);
+    return this.setTime(+this + diff);
   }
   // Set the minutes (from 0-59) in the current timezone
   this.setMinutes = function setMinutes(v) {


### PR DESCRIPTION
it produces Invalid Date

```
 { Invalid Date
   getTimezone: [Function: getTimezone],
   setTimezone: [Function: setTimezone],
   getTimeZone: [Function: getTimezone],
   setTimeZone: [Function: setTimezone],
   getTimezoneAbbr: [Function: getTimezoneAbbr],
```
