### PR TITLE
add timezone directory for illumos/sunos systems

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,6 +23,7 @@ var _Date = process.env.NODE_MODULE_CONTEXTS ? Date : require('vm').runInNewCont
 var possibleTzdirs = [
     '/usr/share/zoneinfo'
   , '/usr/lib/zoneinfo'
+  , '/usr/share/lib/zoneinfo'
 ];
 var TZDIR = process.env.TZDIR;
 while (!TZDIR && possibleTzdirs.length > 0) {


### PR DESCRIPTION
Hi!

Solaris, and by extension illumos/openindiana, etc, keeps timezone data in /usr/share/lib/zoneinfo.  This patch adds it to the search list.  I ran test.js before and after -- output is in a comment on the commit.

Cheers.
