### PR TITLE
Fixes #28: Incorrect timezone calculation on edge of months.

### DIFF
--- a/index.js
+++ b/index.js
@@ -234,13 +234,13 @@ function setTimezone (timezone, relative) {
   // the same (i.e. the Date's internal time value will be changed)
   var ms, s, m, h, d, mo, y
   if (relative) {
-    ms = this.getMilliseconds()
-    s  = this.getSeconds()
-    m  = this.getMinutes()
-    h  = this.getHours()
-    d  = this.getDate()
-    mo = this.getMonth()
     y  = this.getFullYear()
+    mo = this.getMonth()
+    d  = this.getDate()
+    h  = this.getHours()
+    m  = this.getMinutes()
+    s  = this.getSeconds()
+    ms = this.getMilliseconds()
   }
 
   // If the current process timezone doesn't match the desired timezone, then call
@@ -423,13 +423,13 @@ function setTimezone (timezone, relative) {
   this.toLocaleString = this.toString;
 
   if (relative) {
-    this.setMilliseconds(ms)
-    this.setSeconds(s)
-    this.setMinutes(m)
-    this.setHours(h)
-    this.setDate(d)
-    this.setMonth(mo)
     this.setFullYear(y)
+    this.setMonth(mo)
+    this.setDate(d)
+    this.setHours(h)
+    this.setMinutes(m)
+    this.setSeconds(s)
+    this.setMilliseconds(ms)
     ms = s = m = h = d = mo = y = null
   }
 

--- a/test/date.js
+++ b/test/date.js
@@ -126,6 +126,33 @@ describe('Date', function () {
         d.getTime().should.not.equal(old)
       })
 
+      it('should calculate correctly even between months', function () {
+        var forwards = {
+            timezone: 'US/Pacific', hour: 22, minute: 47,
+            year: 2013, month: 1, date: 31
+        };
+        var d = new time.Date(
+          forwards.year, forwards.month - 1, forwards.date,
+          forwards.hour, forwards.minute, 1, 1, forwards.timezone
+        );
+        d.toString().should.equal('Thu Jan 31 2013 22:47:01 GMT-0800 (PST)');
+        d.setTimezone('UTC');
+        d.toString().should.equal('Fri Feb 01 2013 06:47:01 GMT+0000 (UTC)');
+
+        var backwards = {
+            timezone: 'Australia/Sydney', hour: 2, minute: 47,
+            year: 2013, month: 2, date: 1
+        };
+        var d = new time.Date(
+          backwards.year, backwards.month - 1, backwards.date,
+          backwards.hour, backwards.minute, 1, 1, backwards.timezone
+        );
+        d.toString().should.equal('Fri Feb 01 2013 02:47:01 GMT+1100 (EST)');
+        d.setTimezone('UTC');
+        d.toString().should.equal('Thu Jan 31 2013 15:47:01 GMT+0000 (UTC)');
+
+      })
+
     })
 
   })


### PR DESCRIPTION
This patch fixes the problems of issue #28, where timezones different than UTC would produce incorrect datetimes on the last days of a month.

This patch reverses the order of operation during calculations of relative timezone, to prevent the day-month combination to be incorrect mid-step.
