### PR TITLE
Chaining setTimezone()

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-
 /**
  * Module dependencies.
  */
@@ -451,6 +450,7 @@ function setTimezone (timezone, relative) {
     return this.setTime( (t * MILLIS_PER_SECOND) + this.getMilliseconds() );
   }
 
+  return this;
 }
 
 // Returns a "String" of the last value set in "setTimezone".


### PR DESCRIPTION
Hi :)

I just add `return this;` at the end of setTimezone() method.

With that, we can do :

<pre>
  var now = new time.Date().setTimezone("America/Los_Angeles");
</pre>


Thanks for you awesome module :)
