### PR TITLE
Fixed the year 2038 problem.

### DIFF
--- a/src/time.cc
+++ b/src/time.cc
@@ -63,7 +63,7 @@ class Time {
     HandleScope scope;
 
     // Construct the 'tm' struct
-    time_t rawtime = static_cast<time_t>(args[0]->Int32Value());
+    time_t rawtime = static_cast<time_t>(args[0]->IntegerValue());
     struct tm *timeinfo = localtime( &rawtime );
 
     // Create the return "Object"
@@ -121,7 +121,7 @@ class Time {
     tmstr.tm_isdst = arg->Get(String::NewSymbol("isDaylightSavings"))->Int32Value();
     // tm_wday and tm_yday are ignored for input, but properly set after 'mktime' is called
 
-    return scope.Close(Integer::New(mktime( &tmstr )));
+    return scope.Close(Number::New(static_cast<double>(mktime( &tmstr ))));
   }
 
 };

--- a/test/date.js
+++ b/test/date.js
@@ -37,6 +37,24 @@ describe('Date', function () {
       d1.getTimezone().should.equal('America/New_York')
       d2.getTimezone().should.equal('America/Los_Angeles')
     })
+
+
+    it('should parse strings around 2038', function() {
+
+      //Before threshold
+      var d = new time.Date('2037-12-31 11:59:59 PM', 'UTC')
+      d.getTime().should.equal(2145916799000)
+      //After threshold
+      d = new time.Date('2038-01-01 00:00:00 AM', 'UTC')
+      d.getTime().should.equal(2145916800000)
+      
+      //Before threshold
+      d = new time.Date('2038-1-19 03:14:06 AM', 'UTC')
+      d.getTime().should.equal(2147483646000)
+      //After threshold
+      d = new time.Date('2038-1-19 03:14:07 AM', 'UTC')
+      d.getTime().should.equal(2147483647000)
+    })
   })
 
   describe('#setTimezone()', function () {


### PR DESCRIPTION
There were some integer overflow. So it caused problems like:

``` javascript
var d = new time.Date('2038-1-19 03:14:07 AM', 'UTC');
console.log( d.toString());
console.log( d.getTime());
```

Result:

```
Sat Dec 14 1901 03:14:07 GMT+0000 (UTC)
-2147460353000
```
