### PR TITLE
Fix timezone formatting in toTimeString() for half-hour time zones.

### DIFF
--- a/index.js
+++ b/index.js
@@ -472,8 +472,11 @@ function setTimezone (timezone, relative) {
   }
 
   this.toTimeString = function toTimeString() {
-    var offset = zoneInfo.gmtOffset / 60 / 60;
-    return this.toLocaleTimeString() + ' GMT' + (offset >= 0 ? '+' : '-') + pad(Math.abs(offset * 100), 4)
+    var offset = Math.abs(zoneInfo.gmtOffset / 60); // total minutes
+    // split into HHMM:
+    var hours = pad(Math.floor(offset / 60), 2);
+    var minutes = pad(offset % 60, 2);
+    return this.toLocaleTimeString() + ' GMT' + (zoneInfo.gmtOffset >= 0 ? '+' : '-') + hours + minutes
       + ' (' + tz.tzname[zoneInfo.isDaylightSavings ? 1 : 0] + ')';
   }
 

--- a/test/date.js
+++ b/test/date.js
@@ -241,6 +241,14 @@ describe('Date', function () {
         assert.equal(d.toString(), 'Fri Feb 01 2013 09:02:03 GMT+0000 (UTC)')
       })
 
+      it('should produce the right time string for half-hour time offsets', function() {
+        var d = new time.Date("2014-01-17T13:14:15-0330")
+        d.setTimezone('America/St_Johns')
+        assert.equal(d.toString(), 'Fri Jan 17 2014 13:14:15 GMT-0330 (NST)')
+        d.setTimezone('UTC')
+        assert.equal(d.toString(), 'Fri Jan 17 2014 16:44:15 GMT+0000 (UTC)')
+      })
+
     })
 
   })


### PR DESCRIPTION
The old code would produce a timezone like `GMT+0350` instead of `GMT+0330`.
