### PR TITLE
Fix failing test assertion

### DIFF
--- a/test/date.js
+++ b/test/date.js
@@ -229,7 +229,7 @@ describe('Date', function () {
           backwards.year, backwards.month - 1, backwards.date,
           backwards.hour, backwards.minute, 1, 1, backwards.timezone
         )
-        assert.equal(d2.toString(), 'Fri Feb 01 2013 02:47:01 GMT+1100 (EST)')
+        assert.equal(d2.toString(), 'Fri Feb 01 2013 02:47:01 GMT+1100 (AEDT)')
         d2.setTimezone('UTC')
         assert.equal(d2.toString(), 'Thu Jan 31 2013 15:47:01 GMT+0000 (UTC)')
       })


### PR DESCRIPTION
As reported by @nkcmr here: https://github.com/TooTallNate/node-time/issues/65#issuecomment-73411243
On node-0.10 (and 0.12 and iojs):
```
1) Date #setTimezone() relative should calculate correctly when UTC date is day before timezone date:
     AssertionError: "Fri Feb 01 2013 02:47:01 GMT+1100 (AEDT)" == "Fri Feb 01 2013 02:47:01 GMT+1100 (EST)"
      at Context.<anonymous> (/Users/hugues/Documents/node-time/test/date.js:234:16)
```

Tuning on the debugs and reading the test I think the code behaves correctly and the test assertion needs to be fixed.
The date is created here:
```
var backwards = {
          timezone: 'Australia/Sydney', hour: 2, minute: 47,
          year: 2013, month: 2, date: 1
        }
var d2 = new time.Date(
          backwards.year, backwards.month - 1, backwards.date,
          backwards.hour, backwards.minute, 1, 1, backwards.timezone
        )
```
so it should be expected that the timezone of `d2` is indeed `Australia/Sidney` canonically known as `AEDT`.